### PR TITLE
Implement NestJS Config Service to replace custom loadEnv() function

### DIFF
--- a/apps/api/src/app/app.module.ts
+++ b/apps/api/src/app/app.module.ts
@@ -4,8 +4,7 @@ import { UsersAndAuthModule } from '../users-and-auth/users-and-auth.module';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { dataSourceConfig } from '../database/datasource';
 import { ResourcesModule } from '../resources/resources.module';
-import { ConfigModule } from '@nestjs/config';
-import { storageConfig } from '../config/storage.config';
+import { ConfigModule } from '../config/config.module';
 import { ServeStaticModule } from '@nestjs/serve-static';
 import { resolve, join } from 'path';
 import { EventEmitterModule } from '@nestjs/event-emitter';
@@ -24,10 +23,7 @@ console.log('Serving docs from: ', docsPath);
 
 @Module({
   imports: [
-    ConfigModule.forRoot({
-      load: [storageConfig],
-      isGlobal: true,
-    }),
+    ConfigModule, // Import the global ConfigModule
     EventEmitterModule.forRoot(),
     UsersAndAuthModule,
     TypeOrmModule.forRoot(dataSourceConfig),

--- a/apps/api/src/config/config.module.ts
+++ b/apps/api/src/config/config.module.ts
@@ -1,17 +1,38 @@
 import { Global, Module } from '@nestjs/common';
-import { ConfigModule as NestConfigModule } from '@nestjs/config';
+import { ConfigModule as EnvConfigModule } from '@attraccess/env';
 import { storageConfig } from './storage.config';
+import { databaseConfig } from '../database/datasource';
+import { emailConfig } from '../email/email.config';
+import { z } from 'zod';
 
+/**
+ * Global configuration module that validates environment variables
+ * and provides configuration values to the application
+ */
 @Global()
 @Module({
   imports: [
-    NestConfigModule.forRoot({
-      load: [storageConfig],
-      // Cache the configuration
-      cache: true,
-      // Make configuration available everywhere
-      isGlobal: true,
-    }),
+    EnvConfigModule.forRootWithZod(
+      z.object({
+        // Add global environment variables here
+        NODE_ENV: z.enum(['development', 'production', 'test']).default('development'),
+        // Static file paths
+        STATIC_FRONTEND_FILE_PATH: z.string().optional(),
+        STATIC_DOCS_FILE_PATH: z.string().optional(),
+      }),
+      {
+        // Load all configuration providers
+        load: [
+          storageConfig,
+          databaseConfig,
+          emailConfig,
+        ],
+        // Cache the configuration
+        cache: true,
+        // Make configuration available everywhere
+        isGlobal: true,
+      }
+    ),
   ],
 })
 export class ConfigModule {}

--- a/apps/api/src/config/storage.config.ts
+++ b/apps/api/src/config/storage.config.ts
@@ -1,29 +1,32 @@
 import * as path from 'path';
-import { loadEnv } from '@attraccess/env';
+import { createConfigSchema, validateConfig } from '@attraccess/env';
+import { z } from 'zod';
+import { registerAs } from '@nestjs/config';
 
-// Core environment variables validated at startup
-export const env = loadEnv((z) => ({
+// Define the storage environment schema
+const storageEnvSchema = createConfigSchema((z) => ({
   STORAGE_ROOT: z.string().default(path.join(process.cwd(), 'storage')),
-  MAX_FILE_SIZE_BYTES: z.number().default(10 * 1024 * 1024), // 10MB
-  CACHE_MAX_AGE_DAYS: z.number().default(7),
+  MAX_FILE_SIZE_BYTES: z.coerce.number().default(10 * 1024 * 1024), // 10MB
+  CACHE_MAX_AGE_DAYS: z.coerce.number().default(7),
 }));
 
+// Validate the environment variables at startup
+const env = validateConfig(storageEnvSchema);
+
 // Runtime configuration that can be overridden
-export const storageConfig = () => ({
-  storage: {
-    root: env.STORAGE_ROOT,
-    maxFileSize: env.MAX_FILE_SIZE_BYTES,
-    allowedMimeTypes: ['image/jpeg', 'image/png', 'image/webp'] as const,
-    cache: {
-      maxAgeDays: env.CACHE_MAX_AGE_DAYS,
-      directory: path.join(env.STORAGE_ROOT, 'cache'),
-    },
-    resources: {
-      directory: path.join(env.STORAGE_ROOT, 'resources'),
-    },
+export const storageConfig = registerAs('storage', () => ({
+  root: env.STORAGE_ROOT,
+  maxFileSize: env.MAX_FILE_SIZE_BYTES,
+  allowedMimeTypes: ['image/jpeg', 'image/png', 'image/webp'] as const,
+  cache: {
+    maxAgeDays: env.CACHE_MAX_AGE_DAYS,
+    directory: path.join(env.STORAGE_ROOT, 'cache'),
   },
-});
+  resources: {
+    directory: path.join(env.STORAGE_ROOT, 'resources'),
+  },
+}));
 
 // Type definitions for strongly typed access
-export type StorageConfig = ReturnType<typeof storageConfig>['storage'];
+export type StorageConfig = ReturnType<typeof storageConfig>;
 export type AllowedMimeType = StorageConfig['allowedMimeTypes'][number];

--- a/apps/api/src/database/datasource.ts
+++ b/apps/api/src/database/datasource.ts
@@ -1,16 +1,23 @@
 // typeorm.config.ts
 
 import { DataSource, DataSourceOptions } from 'typeorm';
-import { loadEnv } from '@attraccess/env';
+import { createConfigSchema, validateConfig } from '@attraccess/env';
 import { join, resolve } from 'path';
 import { entities } from '@attraccess/database-entities';
 import * as migrations from './migrations';
 import { storageConfig } from '../config/storage.config';
+import { registerAs } from '@nestjs/config';
+import { z } from 'zod';
 
-const envType = loadEnv((z) => ({
+// Define database type schema
+const dbTypeSchema = createConfigSchema((z) => ({
   DB_TYPE: z.enum(['postgres', 'sqlite']).default('sqlite'),
 }));
 
+// Validate database type at startup
+const envType = validateConfig(dbTypeSchema);
+
+// Define base database configuration
 let dbConfig: Partial<DataSourceOptions> = {
   type: envType.DB_TYPE,
   synchronize: false,
@@ -20,17 +27,22 @@ let dbConfig: Partial<DataSourceOptions> = {
   entities: Object.values(entities),
 };
 
+// Define PostgreSQL configuration schema
+const postgresSchema = createConfigSchema((z) => ({
+  DB_HOST: z.string(),
+  DB_PORT: z.coerce
+    .number()
+    .int()
+    .min(1)
+    .max(65535),
+  DB_USERNAME: z.string(),
+  DB_PASSWORD: z.string(),
+  DB_DATABASE: z.string(),
+}));
+
 function loadPostgresConfig() {
-  const env = loadEnv((z) => ({
-    DB_HOST: z.string(),
-    DB_PORT: z
-      .string()
-      .refine((port: string) => parseInt(port) > 0 && parseInt(port) < 65536)
-      .transform((port: string) => parseInt(port)),
-    DB_USERNAME: z.string(),
-    DB_PASSWORD: z.string(),
-    DB_DATABASE: z.string(),
-  }));
+  // Validate PostgreSQL configuration at startup
+  const env = validateConfig(postgresSchema);
 
   dbConfig = {
     ...dbConfig,
@@ -44,9 +56,9 @@ function loadPostgresConfig() {
 }
 
 function loadSqliteConfig() {
-  const dbFile = resolve(join(storageConfig().storage.root, 'attraccess.sqlite'));
+  const dbFile = resolve(join(storageConfig().root, 'attraccess.sqlite'));
 
-  console.log('dbFile', dbFile);
+  console.log('SQLite database file:', dbFile);
 
   dbConfig = {
     ...dbConfig,
@@ -55,6 +67,7 @@ function loadSqliteConfig() {
   } as DataSourceOptions;
 }
 
+// Load the appropriate database configuration based on the database type
 switch (envType.DB_TYPE) {
   case 'postgres':
     loadPostgresConfig();
@@ -68,6 +81,11 @@ switch (envType.DB_TYPE) {
     throw new Error('Unknown Database type in DB_TYPE env');
 }
 
+// Export the database configuration for use in the application
 export const dataSourceConfig = dbConfig;
 
+// Export a database configuration provider for NestJS
+export const databaseConfig = registerAs('database', () => dbConfig);
+
+// Export a DataSource instance for TypeORM
 export default new DataSource(dataSourceConfig as DataSourceOptions);

--- a/apps/api/src/email/email.config.ts
+++ b/apps/api/src/email/email.config.ts
@@ -1,37 +1,35 @@
-import { loadEnv } from '@attraccess/env';
+import { createConfigSchema, validateConfig } from '@attraccess/env';
 import { MailerOptions } from '@nestjs-modules/mailer';
 import { HandlebarsAdapter } from '@nestjs-modules/mailer/dist/adapters/handlebars.adapter';
 import { join } from 'path';
+import { registerAs } from '@nestjs/config';
+import { z } from 'zod';
 
-const basicEmailEnv = loadEnv((z) => ({
+// Define basic email configuration schema
+const basicEmailSchema = createConfigSchema((z) => ({
   SMTP_SERVICE: z.enum(['SMTP', 'Outlook365']),
   SMTP_FROM: z.string().email(),
 }));
 
+// Validate basic email configuration at startup
+const basicEmailEnv = validateConfig(basicEmailSchema);
+
+// Define SMTP configuration schema
+const smtpSchema = createConfigSchema((z) => ({
+  SMTP_HOST: z.string(),
+  SMTP_PORT: z.coerce.number(),
+  SMTP_USER: z.string().optional(),
+  SMTP_PASS: z.string().optional(),
+  SMTP_SECURE: z.coerce.boolean().default(false),
+  SMTP_TLS_CIPHERS: z.string().optional(),
+  SMTP_IGNORE_TLS: z.coerce.boolean().default(true),
+  SMTP_REQUIRE_TLS: z.coerce.boolean().default(false),
+  SMTP_TLS_REJECT_UNAUTHORIZED: z.coerce.boolean().default(true),
+}));
+
 const getSMTPTransportOptions = () => {
-  const smtpEnv = loadEnv((z) => ({
-    SMTP_HOST: z.string(),
-    SMTP_PORT: z.coerce.number(),
-    SMTP_USER: z.string().optional(),
-    SMTP_PASS: z.string().optional(),
-    SMTP_SECURE: z
-      .string()
-      .transform((v) => v === 'true')
-      .default('false'),
-    SMTP_TLS_CIPHERS: z.string().optional(),
-    SMTP_IGNORE_TLS: z
-      .string()
-      .transform((v) => v === 'true')
-      .default('true'),
-    SMTP_REQUIRE_TLS: z
-      .string()
-      .transform((v) => v === 'true')
-      .default('false'),
-    SMTP_TLS_REJECT_UNAUTHORIZED: z
-      .string()
-      .transform((v) => v === 'true')
-      .default('true'),
-  }));
+  // Validate SMTP configuration at startup
+  const smtpEnv = validateConfig(smtpSchema);
 
   let smtpAuthOptions = null;
   if (smtpEnv.SMTP_USER) {
@@ -57,11 +55,15 @@ const getSMTPTransportOptions = () => {
   };
 };
 
+// Define Outlook365 configuration schema
+const outlook365Schema = createConfigSchema((z) => ({
+  SMTP_USER: z.string(),
+  SMTP_PASS: z.string(),
+}));
+
 const getOutlook365TransportOptions = () => {
-  const env = loadEnv((z) => ({
-    SMTP_USER: z.string(),
-    SMTP_PASS: z.string(),
-  }));
+  // Validate Outlook365 configuration at startup
+  const env = validateConfig(outlook365Schema);
 
   return {
     service: 'Outlook365',
@@ -72,6 +74,7 @@ const getOutlook365TransportOptions = () => {
   };
 };
 
+// Determine the transport configuration based on the service type
 let transport = {};
 switch (basicEmailEnv.SMTP_SERVICE) {
   case 'SMTP':
@@ -82,6 +85,7 @@ switch (basicEmailEnv.SMTP_SERVICE) {
     break;
 }
 
+// Create the mailer configuration
 const config = {
   transport,
   defaults: {
@@ -96,4 +100,8 @@ const config = {
   },
 };
 
+// Export the mailer configuration for direct use
 export const mailerConfig: MailerOptions = config;
+
+// Export a configuration provider for NestJS
+export const emailConfig = registerAs('email', () => config);

--- a/apps/api/src/email/email.module.ts
+++ b/apps/api/src/email/email.module.ts
@@ -1,10 +1,22 @@
 import { Module } from '@nestjs/common';
 import { MailerModule } from '@nestjs-modules/mailer';
+import { ConfigModule, ConfigService } from '@nestjs/config';
 import { EmailService } from './email.service';
 import { mailerConfig } from './email.config';
 
 @Module({
-  imports: [MailerModule.forRoot(mailerConfig)],
+  imports: [
+    ConfigModule, // Import ConfigModule to use ConfigService
+    MailerModule.forRootAsync({
+      imports: [ConfigModule],
+      useFactory: (configService: ConfigService) => {
+        // Use the configuration from the ConfigService if available,
+        // otherwise fall back to the static configuration
+        return configService.get('email') || mailerConfig;
+      },
+      inject: [ConfigService],
+    }),
+  ],
   providers: [EmailService],
   exports: [EmailService],
 })

--- a/apps/api/src/main.bootstrap.ts
+++ b/apps/api/src/main.bootstrap.ts
@@ -6,12 +6,16 @@ import { WsAdapter } from '@nestjs/platform-ws';
 import { ConfigService } from '@nestjs/config';
 import { NestExpressApplication } from '@nestjs/platform-express';
 import session from 'express-session';
-import { loadEnv } from '@attraccess/env';
+import { createConfigSchema, validateConfig } from '@attraccess/env';
 import { DataSource } from 'typeorm';
+import { z } from 'zod';
 
-const env = loadEnv((z) => ({
+// Validate auth session secret at startup
+const authSchema = createConfigSchema((z) => ({
   AUTH_SESSION_SECRET: z.string(),
 }));
+
+const env = validateConfig(authSchema);
 
 export async function bootstrap() {
   const bootstrapLogger = new Logger('Bootstrap');

--- a/libs/env/README.md
+++ b/libs/env/README.md
@@ -1,6 +1,135 @@
-# env
+# Environment Configuration
 
-This library was generated with [Nx](https://nx.dev).
+This library provides utilities for loading and validating environment variables using NestJS ConfigModule and Zod.
+
+## Usage
+
+### Basic Usage
+
+```typescript
+import { ConfigService } from '@nestjs/config';
+
+@Injectable()
+export class MyService {
+  constructor(private configService: ConfigService) {
+    // Get a configuration value
+    const value = this.configService.get<string>('key');
+    
+    // Get a nested configuration value
+    const storageRoot = this.configService.get<string>('storage.root');
+  }
+}
+```
+
+### Configuration Module
+
+The ConfigModule is a global module that provides configuration values to the application. It uses Zod for validation and NestJS ConfigModule for configuration management.
+
+```typescript
+import { ConfigModule } from '@attraccess/env';
+import { z } from 'zod';
+
+@Module({
+  imports: [
+    ConfigModule.forRootWithZod(
+      z.object({
+        // Define environment variables with validation
+        NODE_ENV: z.enum(['development', 'production', 'test']).default('development'),
+        PORT: z.coerce.number().default(3000),
+      }),
+      {
+        // Load configuration providers
+        load: [myConfig],
+        // Cache the configuration
+        cache: true,
+        // Make configuration available everywhere
+        isGlobal: true,
+      }
+    ),
+  ],
+})
+export class AppModule {}
+```
+
+### Configuration Providers
+
+Configuration providers are functions that return configuration objects. They can be registered with the ConfigModule using the `load` option.
+
+```typescript
+import { registerAs } from '@nestjs/config';
+import { createConfigSchema, validateConfig } from '@attraccess/env';
+import { z } from 'zod';
+
+// Define the schema
+const mySchema = createConfigSchema((z) => ({
+  MY_ENV_VAR: z.string(),
+  MY_NUMBER: z.coerce.number().default(42),
+}));
+
+// Validate the environment variables at startup
+const env = validateConfig(mySchema);
+
+// Create a configuration provider
+export const myConfig = registerAs('myNamespace', () => ({
+  myEnvVar: env.MY_ENV_VAR,
+  myNumber: env.MY_NUMBER,
+}));
+```
+
+### Legacy Support
+
+For backward compatibility, the `loadEnv` function is still available but marked as deprecated. It's recommended to use the ConfigService instead.
+
+```typescript
+import { loadEnv } from '@attraccess/env';
+
+// This still works but is deprecated
+const env = loadEnv((z) => ({
+  MY_ENV_VAR: z.string(),
+}));
+```
+
+## Migration Guide
+
+To migrate from the old `loadEnv` approach to the new ConfigService:
+
+1. Create a configuration schema using `createConfigSchema`
+2. Validate the environment variables using `validateConfig`
+3. Create a configuration provider using `registerAs`
+4. Register the configuration provider with the ConfigModule
+5. Inject the ConfigService into your services
+6. Use the ConfigService to get configuration values
+
+Example:
+
+```typescript
+// Before
+const env = loadEnv((z) => ({
+  MY_ENV_VAR: z.string(),
+}));
+
+// After
+const mySchema = createConfigSchema((z) => ({
+  MY_ENV_VAR: z.string(),
+}));
+
+const env = validateConfig(mySchema);
+
+export const myConfig = registerAs('myNamespace', () => ({
+  myEnvVar: env.MY_ENV_VAR,
+}));
+```
+
+Then in your service:
+
+```typescript
+@Injectable()
+export class MyService {
+  constructor(private configService: ConfigService) {
+    const myEnvVar = this.configService.get<string>('myNamespace.myEnvVar');
+  }
+}
+```
 
 ## Building
 

--- a/libs/env/src/lib/config/config.module.ts
+++ b/libs/env/src/lib/config/config.module.ts
@@ -1,0 +1,44 @@
+import { DynamicModule, Global, Module } from '@nestjs/common';
+import { ConfigModule as NestConfigModule, ConfigModuleOptions } from '@nestjs/config';
+import { z } from 'zod';
+import { validateConfig } from './validation';
+
+@Global()
+@Module({})
+export class ConfigModule {
+  /**
+   * Register the ConfigModule with validation
+   * @param options Configuration options
+   * @returns A dynamic module
+   */
+  static forRoot(options: ConfigModuleOptions = {}): DynamicModule {
+    return {
+      module: ConfigModule,
+      imports: [
+        NestConfigModule.forRoot({
+          cache: true,
+          isGlobal: true,
+          ...options,
+          validate: options.validate || undefined,
+        }),
+      ],
+      exports: [NestConfigModule],
+    };
+  }
+
+  /**
+   * Register the ConfigModule with Zod validation
+   * @param schema The Zod schema to validate against
+   * @param options Additional configuration options
+   * @returns A dynamic module
+   */
+  static forRootWithZod<T extends z.ZodTypeAny>(
+    schema: T,
+    options: Omit<ConfigModuleOptions, 'validate'> = {},
+  ): DynamicModule {
+    return this.forRoot({
+      ...options,
+      validate: (config) => validateConfig(schema, config),
+    });
+  }
+}

--- a/libs/env/src/lib/config/env-compat.ts
+++ b/libs/env/src/lib/config/env-compat.ts
@@ -1,0 +1,51 @@
+import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { z } from 'zod';
+import { createConfigSchema } from './validation';
+
+/**
+ * Compatibility layer for the loadEnv function
+ * This service allows existing code to continue using the loadEnv pattern
+ * while leveraging the NestJS ConfigService under the hood
+ */
+@Injectable()
+export class EnvCompatService {
+  constructor(private configService: ConfigService) {}
+
+  /**
+   * Load environment variables with validation
+   * @param schemaFn A function that takes Zod and returns a schema definition
+   * @param env The environment object (defaults to process.env)
+   * @returns The validated environment variables
+   */
+  loadEnv<TSchema extends { [key: string]: z.ZodType }>(
+    schemaFn: (zod: typeof z) => TSchema,
+    env: Record<string, unknown> = process.env,
+  ): z.infer<z.ZodObject<TSchema>> {
+    const schema = createConfigSchema(schemaFn);
+    return schema.parse(env);
+  }
+
+  /**
+   * Get a configuration value
+   * @param key The configuration key
+   * @returns The configuration value
+   */
+  get<T = any>(key: string): T {
+    return this.configService.get<T>(key);
+  }
+
+  /**
+   * Get a required configuration value
+   * @param key The configuration key
+   * @returns The configuration value
+   * @throws If the configuration value is not defined
+   */
+  getRequired<T = any>(key: string): T {
+    const value = this.configService.get<T>(key);
+    if (value === undefined) {
+      throw new Error(`Required configuration key "${key}" is not defined`);
+    }
+    return value;
+  }
+}

--- a/libs/env/src/lib/config/index.ts
+++ b/libs/env/src/lib/config/index.ts
@@ -1,0 +1,3 @@
+export * from './config.module';
+export * from './env-compat';
+export * from './validation';

--- a/libs/env/src/lib/config/validation.ts
+++ b/libs/env/src/lib/config/validation.ts
@@ -1,0 +1,36 @@
+import { z } from 'zod';
+
+/**
+ * Validates environment variables against a Zod schema
+ * @param schema The Zod schema to validate against
+ * @param config The configuration object to validate (typically process.env)
+ * @returns The validated configuration object
+ * @throws If validation fails
+ */
+export function validateConfig<T extends z.ZodTypeAny>(
+  schema: T,
+  config: Record<string, unknown> = process.env,
+): z.infer<T> {
+  const result = schema.safeParse(config);
+
+  if (!result.success) {
+    console.error('❌ Invalid environment variables:');
+    const formattedError = result.error.format();
+    console.error(JSON.stringify(formattedError, null, 2));
+    throw new Error('Invalid environment configuration');
+  }
+
+  return result.data;
+}
+
+/**
+ * Creates a Zod schema from a schema definition function
+ * @param schemaFn A function that takes Zod and returns a schema definition
+ * @returns A Zod object schema
+ */
+export function createConfigSchema<TSchema extends { [key: string]: z.ZodType }>(
+  schemaFn: (zod: typeof z) => TSchema,
+): z.ZodObject<TSchema> {
+  const zodSchema = schemaFn(z);
+  return z.object(zodSchema);
+}

--- a/libs/env/src/lib/env.ts
+++ b/libs/env/src/lib/env.ts
@@ -1,13 +1,22 @@
 import { z } from 'zod';
+import { createConfigSchema } from './config/validation';
+
+// Re-export all configuration utilities
+export * from './config';
 
 type SchemaDefinition = { [key: string]: z.ZodType };
 
+/**
+ * Load environment variables with validation
+ * @deprecated Use the NestJS ConfigService instead
+ * @param schema A function that takes Zod and returns a schema definition
+ * @param env The environment object (defaults to process.env)
+ * @returns The validated environment variables
+ */
 export function loadEnv<TSchema extends SchemaDefinition>(
   schema: (zod: typeof z) => TSchema,
   env: typeof process.env = process.env
 ): z.infer<z.ZodObject<TSchema>> {
-  const zodSchema = schema(z);
-  const envSchema = z.object(zodSchema);
-
+  const envSchema = createConfigSchema(schema);
   return envSchema.parse(env);
 }


### PR DESCRIPTION
Resolves #44

## Changes

- Created a new configuration system using NestJS ConfigModule with Zod validation
- Added backward compatibility layer to maintain existing behavior
- Updated storage, database, and email configurations to use the new pattern
- Added comprehensive documentation in README.md
- Marked loadEnv() as deprecated

## Migration Guide

To migrate from the old `loadEnv` approach to the new ConfigService:

1. Create a configuration schema using `createConfigSchema`
2. Validate the environment variables using `validateConfig`
3. Create a configuration provider using `registerAs`
4. Register the configuration provider with the ConfigModule
5. Inject the ConfigService into your services
6. Use the ConfigService to get configuration values