### PR TITLE
fix(GH-72): refresh webhook list after create/update

### DIFF
--- a/apps/frontend/src/app/resources/iot-settings/webhooks/components/WebhookForm.tsx
+++ b/apps/frontend/src/app/resources/iot-settings/webhooks/components/WebhookForm.tsx
@@ -13,7 +13,7 @@ import {
   useWebhooksServiceCreateOneWebhookConfiguration,
   useWebhooksServiceGetOneWebhookConfigurationById,
   useWebhooksServiceUpdateOneWebhookConfiguration,
-  useWebhooksServiceGetAllWebhookConfigurationsKeyFn,
+  UseWebhooksServiceGetAllWebhookConfigurationsKeyFn,
 } from '@attraccess/react-query-client';
 import { useQueryClient } from '@tanstack/react-query';
 import { useToastMessage } from '../../../../../components/toastProvider';
@@ -104,7 +104,7 @@ const WebhookForm: React.FC<WebhookFormProps> = ({ webhookId, resourceId, initia
           requestBody: values,
         });
         queryClient.invalidateQueries({
-          queryKey: useWebhooksServiceGetAllWebhookConfigurationsKeyFn({ resourceId }),
+          queryKey: UseWebhooksServiceGetAllWebhookConfigurationsKeyFn({ resourceId }),
         });
         success({
           title: t('webhookUpdated'),
@@ -117,7 +117,7 @@ const WebhookForm: React.FC<WebhookFormProps> = ({ webhookId, resourceId, initia
           requestBody: values,
         });
         queryClient.invalidateQueries({
-          queryKey: useWebhooksServiceGetAllWebhookConfigurationsKeyFn({ resourceId }),
+          queryKey: UseWebhooksServiceGetAllWebhookConfigurationsKeyFn({ resourceId }),
         });
         success({
           title: t('webhookCreated'),


### PR DESCRIPTION
Fixes #72. This change ensures that the webhook list is refreshed automatically after a webhook is created or updated by invalidating the relevant React Query cache.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Refresh the list of webhooks by invalidating related query on create/update of a webhook within the `WebhookForm` component.

### Why are these changes being made?
This change ensures the UI reflects the latest data after creating or updating a webhook, addressing the issue described in GH-72 where changes were not visible without manual refresh. The use of `invalidateQueries` ensures the data consistency by refreshing the list of webhook configurations automatically.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->