### PR TITLE
fix(GH-71): Correct documentationType casing mismatch

### DIFF
--- a/apps/frontend/src/app/resources/documentation/DocumentationEditor.tsx
+++ b/apps/frontend/src/app/resources/documentation/DocumentationEditor.tsx
@@ -22,7 +22,7 @@ import {
   useResourcesServiceGetOneResourceById,
   useResourcesServiceUpdateOneResource,
   UseResourcesServiceGetOneResourceByIdKeyFn,
-  DocumentationType,
+  documentationType as DocumentationType, // alias for local usage
 } from '@attraccess/react-query-client';
 import ReactMarkdown from 'react-markdown';
 import en from './documentationEditor.en.json';
@@ -89,8 +89,8 @@ function DocumentationEditorComponent() {
   useEffect(() => {
     if (resource) {
       // Set the documentation type directly from the resource
-      if (resource.DocumentationType) {
-        setDocumentationType(resource.DocumentationType as DocumentationType);
+      if (resource.documentationType) {
+        setDocumentationType(resource.documentationType as DocumentationType);
       } else {
         setDocumentationType('');
       }

--- a/apps/frontend/src/app/resources/documentation/DocumentationModal.tsx
+++ b/apps/frontend/src/app/resources/documentation/DocumentationModal.tsx
@@ -58,9 +58,9 @@ function DocumentationModalComponent({ resourceId, children }: DocumentationModa
   }, [navigate, resourceId]);
 
   const handleOpenInNewTab = useCallback(() => {
-    if (resource?.DocumentationType === 'url' && resource?.documentationUrl) {
+    if (resource?.documentationType === 'url' && resource?.documentationUrl) {
       window.open(resource.documentationUrl, '_blank');
-    } else if (resource?.DocumentationType === 'markdown') {
+    } else if (resource?.documentationType === 'markdown') {
       window.open(`/resources/${resourceId}/documentation`, '_blank');
     }
   }, [resource, resourceId]);
@@ -85,11 +85,11 @@ function DocumentationModalComponent({ resourceId, children }: DocumentationModa
       );
     }
 
-    if (!resource?.DocumentationType) {
+    if (!resource?.documentationType) {
       return <p className="text-center text-default-400 p-4">{t('noDocumentation')}</p>;
     }
 
-    if (resource.DocumentationType === 'markdown' && resource.documentationMarkdown) {
+    if (resource.documentationType === 'markdown' && resource.documentationMarkdown) {
       return (
         <div
           className="prose prose-slate dark:prose-invert max-w-none p-6 
@@ -113,7 +113,7 @@ function DocumentationModalComponent({ resourceId, children }: DocumentationModa
       );
     }
 
-    if (resource.DocumentationType === 'url' && resource.documentationUrl) {
+    if (resource.documentationType === 'url' && resource.documentationUrl) {
       return (
         <iframe
           src={resource.documentationUrl}
@@ -169,7 +169,7 @@ function DocumentationModalComponent({ resourceId, children }: DocumentationModa
                     <ExternalLink size={16} />
                   </Button>
 
-                  {resource?.DocumentationType === 'url' && (
+                  {resource?.documentationType === 'url' && (
                     <Button
                       isIconOnly
                       size="sm"

--- a/apps/frontend/src/app/resources/documentation/DocumentationView.tsx
+++ b/apps/frontend/src/app/resources/documentation/DocumentationView.tsx
@@ -128,15 +128,15 @@ function DocumentationViewComponent() {
             </div>
           )}
 
-          {!resource.DocumentationType && <p className="text-center text-default-400 p-4">{t('noDocumentation')}</p>}
+          {!resource.documentationType && <p className="text-center text-default-400 p-4">{t('noDocumentation')}</p>}
 
-          {resource.DocumentationType === 'markdown' && resource.documentationMarkdown && (
+          {resource.documentationType === 'markdown' && resource.documentationMarkdown && (
             <div className="prose max-w-none">
               <ReactMarkdown>{resource.documentationMarkdown}</ReactMarkdown>
             </div>
           )}
 
-          {resource.DocumentationType === 'url' && resource.documentationUrl && (
+          {resource.documentationType === 'url' && resource.documentationUrl && (
             <iframe
               src={resource.documentationUrl}
               className="w-full h-[calc(100vh-300px)] min-h-[500px] border-0"

--- a/libs/api-client/src/generated/Api.ts
+++ b/libs/api-client/src/generated/Api.ts
@@ -466,7 +466,7 @@ export interface Resource {
    * The type of documentation (markdown or url)
    * @example "markdown"
    */
-  DocumentationType?: "markdown" | "url";
+  documentationType?: "markdown" | "url";
   /**
    * Markdown content for resource documentation
    * @example "# Resource Documentation

--- a/libs/database-entities/src/lib/entities/resource.entity.ts
+++ b/libs/database-entities/src/lib/entities/resource.entity.ts
@@ -57,7 +57,6 @@ export class Resource {
   @ApiProperty({
     description: 'The type of documentation (markdown or url)',
     enum: DocumentationType,
-    name: 'DocumentationType',
     required: false,
     example: DocumentationType.MARKDOWN,
   })

--- a/libs/react-query-client/src/lib/requests/schemas.gen.ts
+++ b/libs/react-query-client/src/lib/requests/schemas.gen.ts
@@ -634,7 +634,7 @@ export const $Resource = {
             description: 'The filename of the resource image',
             example: '1234567890_abcdef.jpg'
         },
-        DocumentationType: {
+        documentationType: {
             type: 'string',
             description: 'The type of documentation (markdown or url)',
             enum: ['markdown', 'url'],

--- a/libs/react-query-client/src/lib/requests/types.gen.ts
+++ b/libs/react-query-client/src/lib/requests/types.gen.ts
@@ -423,7 +423,7 @@ export type Resource = {
     /**
      * The type of documentation (markdown or url)
      */
-    DocumentationType?: 'markdown' | 'url';
+    documentationType?: 'markdown' | 'url';
     /**
      * Markdown content for resource documentation
      */
@@ -449,14 +449,6 @@ export type Resource = {
      */
     groups: Array<ResourceGroup>;
 };
-
-/**
- * The type of documentation (markdown or url)
- */
-export enum DocumentationType {
-    MARKDOWN = 'markdown',
-    URL = 'url'
-}
 
 export type PaginatedResourceResponseDto = {
     total: number;


### PR DESCRIPTION
Fixes #71 by correcting the casing of `documentationType` in the frontend to match the backend. This ensures that the documentation URL and type are correctly saved and displayed when creating or editing a resource.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Correct the casing of `documentationType` across the codebase to address a mismatch issue.

### Why are these changes being made?

The changes are necessary to ensure consistency in casing for the `documentationType` property, which could have led to potential bugs or incorrect behavior in the application. By standardizing the casing, we enhance code readability and reduce ambiguity. The previous mismatch between `DocumentationType` and `documentationType` required a change for cohesion, solving the related bug (GH-71).

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->