### PR TITLE
feat: Add GitHub Action to send issues to OpenHands AI

### DIFF
--- a/.github/workflows/send-to-openhands.yml
+++ b/.github/workflows/send-to-openhands.yml
@@ -1,0 +1,43 @@
+name: Send Issue to OpenHands AI
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  send_to_openhands:
+    if: github.event.comment.user.login == 'jappyjan' && contains(github.event.comment.body, '@ai')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send Issue to OpenHands
+        env:
+          OPENHANDS_API_TOKEN: ${{ secrets.OPENHANDS_API_TOKEN }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          ISSUE_BODY: ${{ github.event.issue.body }}
+          ISSUE_URL: ${{ github.event.issue.html_url }}
+          REPO_URL: ${{ github.event.repository.html_url }}
+          COMMENTER_LOGIN: ${{ github.event.comment.user.login }}
+        run: |
+          # Prepare the initial message
+          INITIAL_USER_MSG=$(printf "GitHub Issue: %s\n\n%s\n\nLink to issue: %s\nTriggered by: %s" \
+          "${ISSUE_TITLE}" \
+          "${ISSUE_BODY}" \
+          "${ISSUE_URL}" \
+          "${COMMENTER_LOGIN}")
+
+          # Construct the JSON payload
+          JSON_PAYLOAD=$(printf '{
+            "initial_user_msg": "%s",
+            "repository": "%s",
+            "git_provider": "github"
+          }' \
+          "${INITIAL_USER_MSG}" \
+          "${{ github.event.repository.full_name }}")
+
+          # Make the API call
+          # Defaulting to production server: https://app.all-hands.dev
+          # Change if you use a local or self-hosted OpenHands instance.
+          curl -X POST https://app.all-hands.dev/api/conversations \
+            -H "Authorization: Bearer ${OPENHANDS_API_TOKEN}" \
+            -H "Content-Type: application/json" \
+            -d "${JSON_PAYLOAD}"


### PR DESCRIPTION
This PR introduces a GitHub Action workflow that allows authorized users (jappyjan) to send GitHub issues to an OpenHands AI instance by commenting "@ai" on the issue.

**Functionality:**

- Triggers on new issue comments.
- Checks if the commenter is "jappyjan" and if the comment contains "@ai".
- If conditions are met, it constructs a payload with the issue title, body, URL, and triggering user.
- Sends a POST request to the OpenHands API (`https://app.all-hands.dev/api/conversations`) to create a new conversation.

**Configuration Required Post-Merge:**

1.  **API Endpoint:** The workflow currently points to `https://app.all-hands.dev/api/conversations`. If a different OpenHands instance (local, self-hosted) is used, this URL must be updated in `.github/workflows/send-to-openhands.yml`.
2.  **GitHub Secret:** A secret named `OPENHANDS_API_TOKEN` must be created in the repository settings. This secret should contain the API token for authenticating with the OpenHands API.
