### PR TITLE
fix(workflow): Remove invalid `needs` from step

### DIFF
--- a/.github/workflows/send-to-openhands.yml
+++ b/.github/workflows/send-to-openhands.yml
@@ -55,7 +55,6 @@ jobs:
           echo "Successfully retrieved Authentik access token."
 
       - name: Send Issue to OpenHands
-        needs: get_token
         env:
           AUTHENTIK_ACCESS_TOKEN: ${{ steps.get_token.outputs.access_token }}
           OPENHANDS_API_HOSTNAME: ${{ secrets.OPENHANDS_API_HOSTNAME }}


### PR DESCRIPTION
Fixes an invalid `needs` keyword in the send-to-openhands.yml workflow file. The `needs` keyword was incorrectly placed at the step level instead of the job level. Since the step it was referring to is within the same job, the `needs` keyword is not necessary and has been removed.