### PR TITLE
fix(workflow): Correctly reference secrets in if condition

### DIFF
--- a/.github/workflows/send-to-openhands.yml
+++ b/.github/workflows/send-to-openhands.yml
@@ -15,7 +15,7 @@ jobs:
     # Required OpenHands & Action secrets:
     #   OPENHANDS_API_HOSTNAME (e.g., your OpenHands instance URL)
     #   ALLOWED_TRIGGER_USERS (Comma-separated GitHub usernames, e.g., jappyjan)
-    if: |
+    if: ${{
       secrets.AUTHENTIK_TOKEN_URL != '' &&
       secrets.AUTHENTIK_CLIENT_ID != '' &&
       secrets.AUTHENTIK_SERVICE_ACCOUNT_USERNAME != '' &&
@@ -23,7 +23,7 @@ jobs:
       secrets.OPENHANDS_API_HOSTNAME != '' &&
       secrets.ALLOWED_TRIGGER_USERS != '' &&
       contains(format(',{0},', secrets.ALLOWED_TRIGGER_USERS), format(',{0},', github.event.comment.user.login)) &&
-      contains(github.event.comment.body, '@ai')
+      contains(github.event.comment.body, '@ai') }}
     runs-on: ubuntu-latest
     steps:
       - name: Get Authentik Access Token


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Correctly reference secrets within the `if` condition by using `${{ }}` syntax in the GitHub Actions workflow file.

### Why are these changes being made?
The previous syntax for the `if` condition was incorrect, leading to potential failures in evaluating the condition. This update ensures that the secrets are correctly interpreted within the workflow, allowing the proper execution of conditional logic based on the presence and values of the secrets and user input.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->