### PR TITLE
feat(GH-85): restrict FabReader access by permission

### DIFF
--- a/apps/frontend/src/app/routes/index.tsx
+++ b/apps/frontend/src/app/routes/index.tsx
@@ -131,7 +131,7 @@ const coreRoutes: RouteConfig[] = [
   {
     path: '/fabreader',
     element: <FabreaderList />,
-    authRequired: true,
+    authRequired: 'canManageSystemConfiguration',
     sidebar: {
       translationKey: 'FabReader',
       icon: <ComputerIcon className="h-5 w-5" />,


### PR DESCRIPTION
This PR restricts the FabReader navigation item and page to users with the `canManageSystemConfiguration` permission. Closes #85

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Restrict access to the FabReader route by requiring the 'canManageSystemConfiguration' permission instead of just authentication.

### Why are these changes being made?

The change enhances security by ensuring only users with the appropriate permission level can access system configuration features within FabReader. This prevents unauthorized users from managing sensitive system configurations and aligns with access control best practices.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->