### PR TITLE
fix(GH-88): correctly transform boolean string

### DIFF
--- a/apps/api/src/resources/dtos/createResource.dto.ts
+++ b/apps/api/src/resources/dtos/createResource.dto.ts
@@ -1,5 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsString, IsOptional, MinLength, IsEnum, IsUrl, ValidateIf, IsBoolean } from 'class-validator';
+import { Transform } from 'class-transformer';
 import { FileUpload } from '../../common/types/file-upload.types';
 import { DocumentationType } from '@attraccess/database-entities';
 
@@ -64,8 +65,10 @@ export class CreateResourceDto {
     required: false,
     example: false,
     default: false,
+    type: Boolean,
   })
   @IsBoolean()
+  @Transform(({ value }) => value === 'true')
   @IsOptional()
   allowTakeOver?: boolean;
 }


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add a transformation to convert the string 'true' into a boolean in the `CreateResourceDto` class.

### Why are these changes being made?

This change ensures that the `allowTakeOver` property is properly converted from a string to a boolean, addressing an issue where boolean values were incorrectly processed as strings in the API requests. Using `@Transform` from `class-transformer` provides a straightforward and reliable method to handle this string-to-boolean conversion.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->