### PR TITLE
fix(email): properly parse SMTP_SECURE values

### DIFF
--- a/apps/api/src/email/email.config.spec.ts
+++ b/apps/api/src/email/email.config.spec.ts
@@ -1,0 +1,52 @@
+
+import { Test } from '@nestjs/testing';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import emailConfiguration from './email.config';
+
+describe('EmailConfiguration', () => {
+  const testCases = [
+    { value: 'true', expected: true },
+    { value: 'false', expected: false },
+    { value: '', expected: false },
+    { value: undefined, expected: false },
+    { value: 'anything', expected: false }
+  ];
+
+  testCases.forEach(({value, expected}) => {
+    it(`should parse SMTP_SECURE=${value} as ${expected}`, async () => {
+      // Clear and set environment variables
+      delete process.env.SMTP_SERVICE;
+      delete process.env.SMTP_HOST;
+      delete process.env.SMTP_PORT;
+      delete process.env.SMTP_FROM;
+      delete process.env.SMTP_SECURE;
+
+      process.env.SMTP_SERVICE = 'SMTP';
+      process.env.SMTP_HOST = 'localhost';
+      process.env.SMTP_PORT = '1025';
+      process.env.SMTP_FROM = 'test@example.com';
+      
+      if (value !== undefined) {
+        process.env.SMTP_SECURE = value;
+      }
+
+      const module = await Test.createTestingModule({
+        imports: [
+          ConfigModule.forRoot({
+            ignoreEnvFile: false,
+          }),
+          ConfigModule.forFeature(emailConfiguration)
+        ],
+      }).compile();
+
+      const config = module.get<ConfigService>(ConfigService).get('email');
+      console.log('Test config:', {
+        input: value,
+        expected,
+        actual: config?.mailerOptions?.transport?.secure,
+        fullConfig: config
+      });
+      expect(config?.mailerOptions?.transport?.secure).toBe(expected);
+    });
+  });
+});

--- a/apps/api/src/email/email.config.ts
+++ b/apps/api/src/email/email.config.ts
@@ -10,7 +10,10 @@ const EmailEnvSchema = z.object({
 const SMTP_ENV_SCHEMA = z.object({
   SMTP_HOST: z.string().min(1, { message: 'SMTP_HOST is required' }),
   SMTP_PORT: z.coerce.number().positive({ message: 'SMTP_PORT must be a positive number' }),
-  SMTP_SECURE: z.coerce.boolean().default(false),
+  SMTP_SECURE: z.string().transform((val) => {
+  console.log('SMTP_SECURE transformation:', { input: val, result: val.toLowerCase() === 'true' });
+  return val.toLowerCase() === 'true';
+}).default('false'),
   SMTP_USER: z.string().optional(),
   SMTP_PASS: z.string().optional(),
   SMTP_FROM: z.string().min(1, { message: 'SMTP_FROM email is required' }),

--- a/apps/api/src/email/email.config.ts
+++ b/apps/api/src/email/email.config.ts
@@ -10,10 +10,7 @@ const EmailEnvSchema = z.object({
 const SMTP_ENV_SCHEMA = z.object({
   SMTP_HOST: z.string().min(1, { message: 'SMTP_HOST is required' }),
   SMTP_PORT: z.coerce.number().positive({ message: 'SMTP_PORT must be a positive number' }),
-  SMTP_SECURE: z.string().transform((val) => {
-  console.log('SMTP_SECURE transformation:', { input: val, result: val.toLowerCase() === 'true' });
-  return val.toLowerCase() === 'true';
-}).default('false'),
+  SMTP_SECURE: z.string().transform((val) => val.toLowerCase() === 'true').default('false'),
   SMTP_USER: z.string().optional(),
   SMTP_PASS: z.string().optional(),
   SMTP_FROM: z.string().min(1, { message: 'SMTP_FROM email is required' }),


### PR DESCRIPTION

This PR fixes issue #154 where SMTP_SECURE was being treated as true for any non-empty value.

Changes:
- Only treat 'true' (case-insensitive) as true
- All other values (false, empty string, undefined, etc.) are treated as false
- Default remains false when not set
- Added comprehensive tests to verify all cases

The fix ensures SMTP connections only use SSL/TLS when explicitly configured to do so.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Refactor the email configuration to properly parse `SMTP_SECURE` values as strings and update the corresponding test suite to ensure accuracy in parsing logic.

### Why are these changes being made?

The previous implementation inaccurately coerced SMTP_SECURE values directly to boolean, potentially misinterpreting input strings. By transforming the string value of `SMTP_SECURE` based on its content, this change ensures explicit handling of the value 'true', thereby improving configuration reliability and aligning with expected environment variable inputs. Additionally, adding comprehensive tests ensures robustness and correctness of the parsing logic.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->


> [!NOTE]
> I'm currently writing a description for your pull request. I should be done shortly (<1 minute). Please don't edit the description field until I'm finished, or we may overwrite each other. If I find nothing to write about, I'll delete this message.
