### PR TITLE
fix(GH-156): correctly determine resource filter permissions

### DIFF
--- a/apps/api/src/resources/resources.controller.ts
+++ b/apps/api/src/resources/resources.controller.ts
@@ -76,10 +76,11 @@ export class ResourcesController {
     let onlyWithPermissionForUserId: number | undefined;
 
     if (!req.user.systemPermissions.canManageResources) {
-      if (query.onlyWithPermissions !== undefined) {
+      if (query.onlyWithPermissions === true) {
         onlyWithPermissionForUserId = req.user.id;
       }
     }
+
     const resources = await this.resourcesService.listResources({
       page: query.page,
       limit: query.limit,


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Correctly determine resource filter permissions by checking if `query.onlyWithPermissions` is strictly true to set `onlyWithPermissionForUserId`.

### Why are these changes being made?
Previously, the permission filter could be incorrectly set, possibly leading to unauthorized resource access or filtering. By ensuring `query.onlyWithPermissions` is strictly true, we accurately determine when to apply user-specific permissions, thus improving security and expected behavior.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->