### PR TITLE
feat(GH-142): show resource image on resource details page

### DIFF
--- a/apps/frontend/src/app/resourceOverview/resourceGroupCard/index.tsx
+++ b/apps/frontend/src/app/resourceOverview/resourceGroupCard/index.tsx
@@ -178,6 +178,9 @@ export function ResourceGroupCard(props: Readonly<Props & Omit<CardProps, 'child
                     isBlurred
                     src={filenameToUrl(resource.imageFilename)}
                     alt={resource.name}
+                    classNames={{
+                      img: 'object-contain',
+                    }}
                   />
                 </TableCell>
                 <TableCell>{resource.name}</TableCell>

--- a/apps/frontend/src/app/resources/details/resourceDetails.tsx
+++ b/apps/frontend/src/app/resources/details/resourceDetails.tsx
@@ -27,6 +27,7 @@ import { ResoureIntroducerManagement } from '../IntroducerManagement';
 import { ResourceIntroductionsManagement } from '../IntroductionsManagement';
 import { ResourceQrCode } from './qrcode';
 import { useQrCodeAction } from './useQrCodeAction';
+import { filenameToUrl } from '../../../api';
 
 function ResourceDetailsComponent() {
   const { id } = useParams<{ id: string }>();
@@ -120,7 +121,9 @@ function ResourceDetailsComponent() {
     <div>
       <PageHeader
         title={resource.name}
-        icon={<ShapesIcon className="w-6 h-6" />}
+        icon={!resource.imageFilename && <ShapesIcon className="w-6 h-6" />}
+        thumbnailSrc={resource.imageFilename ? filenameToUrl(resource.imageFilename) : undefined}
+        thumbnailAlt={resource.name}
         subtitle={resource.description ?? undefined}
         backTo="/resources"
         actions={

--- a/apps/frontend/src/components/pageHeader/index.tsx
+++ b/apps/frontend/src/components/pageHeader/index.tsx
@@ -2,7 +2,7 @@ import React, { ReactNode } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { ArrowLeft } from 'lucide-react';
 import { Button } from '@heroui/button';
-import { cn } from '@heroui/react';
+import { cn, Image } from '@heroui/react';
 
 interface PageHeaderProps {
   title: string;
@@ -11,9 +11,20 @@ interface PageHeaderProps {
   actions?: ReactNode;
   icon?: ReactNode;
   noMargin?: boolean;
+  thumbnailSrc?: string;
+  thumbnailAlt?: string;
 }
 
-export function PageHeader({ title, subtitle, backTo, actions, icon, noMargin }: Readonly<PageHeaderProps>) {
+export function PageHeader({
+  title,
+  subtitle,
+  backTo,
+  actions,
+  icon,
+  noMargin,
+  thumbnailSrc,
+  thumbnailAlt,
+}: Readonly<PageHeaderProps>) {
   const navigate = useNavigate();
 
   return (
@@ -35,6 +46,18 @@ export function PageHeader({ title, subtitle, backTo, actions, icon, noMargin }:
         <div className="flex-shrink">
           <div className="flex items-center gap-2">
             {icon}
+            {thumbnailSrc && (
+              <Image
+                classNames={{
+                  img: 'object-contain',
+                }}
+                height={48}
+                width={48}
+                isBlurred
+                src={thumbnailSrc}
+                alt={thumbnailAlt}
+              />
+            )}
             <h1 className="text-2xl font-bold">{title}</h1>
           </div>
           {subtitle && <p className="mt-1 text-sm text-foreground-500">{subtitle}</p>}


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Display resource images on the resource details page and update the `PageHeader` component to accommodate thumbnail images along with icons.

### Why are these changes being made?

Currently, the resource details page lacks visual representation for resources, limiting user engagement and understanding. By showing resource images, users gain immediate visual context. This approach enhances the user interface without disrupting existing functionalities, thus providing a more informative and appealing UI.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->